### PR TITLE
Some IPA files may use XML formatted plist

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,10 @@
 var zip = require('zipjs-browserify');
 var typedToBuffer = require('typedarray-to-buffer');
-var parse = require('bplist-parser').parseBuffer;
+var bplistParse = require('bplist-parser').parseBuffer;
+var plistParse = require('plist').parse;
+
+var chrOpenChevron = 60;
+var chrLowercaseB = 98;
 
 module.exports = function(blob, cb){
   var onerror = function(err){ cb(err) };
@@ -17,7 +21,17 @@ module.exports = function(blob, cb){
           if (err) return cb(err);
 
           var buf = typedToBuffer(typed);
-          cb(null, parse(buf), buf);
+          var obj;
+
+          if (buf[0] === chrOpenChevron) {
+            obj = plistParse(buf.toString());
+          } else if (buf[0] === chrLowercaseB) {
+            obj = bplistParse(buf);
+          } else {
+            return cb(new Error('unknown plist type %s', buf[0]));
+          }
+
+          cb(null, [].concat(obj), buf);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "bplist-parser": "^0.1.0",
     "collect-stream": "^1.1.1",
+    "plist": "^1.2.0",
     "typedarray-to-buffer": "^3.0.4",
     "yauzl": "^2.3.1",
     "zipjs-browserify": "^1.0.0"


### PR DESCRIPTION
- adds support for plist that is XML instead of binary plist
- tested with the browser and node examples
